### PR TITLE
Adds option to exclude user group mappings

### DIFF
--- a/auth-api/src/auth_api/resources/user.py
+++ b/auth-api/src/auth_api/resources/user.py
@@ -61,7 +61,8 @@ class Users(Resource):
     def get():
         """Fetch all users."""
         include_groups = request.args.get("include_groups", "true").lower() == "true"
-        users = UserService.get_all_users(include_groups=include_groups)
+        search_text = request.args.get("search", None)
+        users = UserService.get_all_users(include_groups=include_groups, search_text=search_text)
         user_list_schema = UserSchema(many=True)
         return user_list_schema.dump(users), HTTPStatus.OK
 

--- a/auth-api/src/auth_api/resources/user.py
+++ b/auth-api/src/auth_api/resources/user.py
@@ -15,7 +15,7 @@
 
 from http import HTTPStatus
 
-from flask import request, current_app
+from flask import request
 from flask_restx import Namespace, Resource
 
 from auth_api.auth import auth
@@ -60,7 +60,8 @@ class Users(Resource):
     @auth.require
     def get():
         """Fetch all users."""
-        users = UserService.get_all_users()
+        include_groups = request.args.get("include_groups", "true").lower() == "true"
+        users = UserService.get_all_users(include_groups=include_groups)
         user_list_schema = UserSchema(many=True)
         return user_list_schema.dump(users), HTTPStatus.OK
 
@@ -178,6 +179,7 @@ class GroupMembers(Resource):
     )
     @API.response(code=200, model=user_response_list_model, description="Group Members List")
     @API.response(404, "Not Found")
+    @auth.require
     def get(group_name):
         """Get group members by name."""
         sub_group_name = request.args.get("sub_group_name", None)

--- a/auth-api/src/auth_api/services/keycloak.py
+++ b/auth-api/src/auth_api/services/keycloak.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Keycloak admin functions."""
+from urllib.parse import urlencode
+
 import requests
 from flask import current_app
 
@@ -54,9 +56,18 @@ class KeycloakService:
         return users[0]
 
     @staticmethod
-    def get_users():
-        """Get users."""
-        response = KeycloakService._request_keycloak("users?max=2000")
+    def get_users(search_text: str = None):
+        """Return a list of users from Keycloak, optionally filtered by search term."""
+        max_users = 2000
+        query_params = {'max': max_users}
+
+        if search_text:
+            query_params['search'] = search_text
+
+        query_string = urlencode(query_params)
+        endpoint = f"users?{query_string}"
+
+        response = KeycloakService._request_keycloak(endpoint)
         return response.json()
 
     @staticmethod

--- a/auth-api/src/auth_api/services/user_service.py
+++ b/auth-api/src/auth_api/services/user_service.py
@@ -34,9 +34,9 @@ class UserService:
         return user
 
     @classmethod
-    def get_all_users(cls, include_groups: bool = True):
+    def get_all_users(cls, include_groups: bool = True, search_text: str = None):
         """Get all users, optionally filtered by app name and with optional group mapping."""
-        users = KeycloakService.get_users()
+        users = KeycloakService.get_users(search_text)
         if not include_groups:
             return users
 

--- a/auth-api/src/auth_api/services/user_service.py
+++ b/auth-api/src/auth_api/services/user_service.py
@@ -34,39 +34,55 @@ class UserService:
         return user
 
     @classmethod
-    def get_all_users(cls):
-        """Get all users, optionally filtered by app name."""
+    def get_all_users(cls, include_groups: bool = True):
+        """Get all users, optionally filtered by app name and with optional group mapping."""
         users = KeycloakService.get_users()
-        app_name = g.app_name
-        groups = sorted(UserService.get_groups(), key=UserService._get_level)
+        if not include_groups:
+            return users
 
-        app_groups = (
-            [
-                group
-                for group in groups
-                if app_name.lower() in group.get("path", "").lower()
-            ]
-            if app_name
-            else groups
-        )
+        app_name = g.get("app_name", None)
+        groups = cls._get_relevant_groups(app_name)
 
-        # Create a dictionary to map group IDs to members
+        group_members_map = cls._map_group_members(groups)
+
+        cls._assign_groups_to_users(users, groups, group_members_map)
+
+        return cls._filter_users_by_group(users) if app_name else users
+
+    @classmethod
+    def _get_relevant_groups(cls, app_name: str):
+        """Return sorted groups, optionally filtered by app name."""
+        all_groups = cls.get_groups()
+        if app_name:
+            return sorted(
+                [group for group in all_groups if app_name.lower() in g.get("path", "").lower()],
+                key=cls._get_level
+            )
+        return sorted(all_groups, key=cls._get_level)
+
+    @classmethod
+    def _map_group_members(cls, groups):
+        """Return a mapping of group_id to set of user_ids."""
         group_members = {}
-        for group in app_groups:
+        for group in groups:
             members = KeycloakService.get_group_members(group["id"])
-            member_ids = {member["id"] for member in members}
-            group_members[group["id"]] = member_ids
+            group_members[group["id"]] = {m["id"] for m in members}
+        return group_members
 
-        # Map users to their groups
+    @classmethod
+    def _assign_groups_to_users(cls, users, groups, group_members_map):
+        """Mutate user objects by adding their group memberships."""
         for user in users:
             user["groups"] = [
                 group
-                for group in app_groups
-                if user["id"] in group_members.get(group["id"], set())
+                for group in groups
+                if user["id"] in group_members_map.get(group["id"], set())
             ]
 
-        # Return only users with at least one group if filtered by app_name
-        return [user for user in users if user["groups"]] if app_name else users
+    @classmethod
+    def _filter_users_by_group(cls, users):
+        """Return only users who belong to at least one group."""
+        return [user for user in users if user["groups"]]
 
     @classmethod
     def _get_level(cls, group):


### PR DESCRIPTION
Adds the ability to exclude group mappings when fetching users. This is useful in scenarios where group information is not required, reducing the amount of data transferred and processed.

- Introduces an `include_groups` parameter to the `get_all_users` method, defaulting to `true`.
- Modifies the `Users` resource to accept the `include_groups` parameter from the request.
- Secures the `get` endpoint in `GroupMembers` resource with authentication.

Relates to CENTRE-29