### PR TITLE
Refactors user lookup by username and ID

### DIFF
--- a/auth-api/src/auth_api/resources/user.py
+++ b/auth-api/src/auth_api/resources/user.py
@@ -68,8 +68,8 @@ class Users(Resource):
 
 
 @cors_preflight("GET, OPTIONS, PATCH, DELETE")
-@API.route("/<user_id>", methods=["PATCH", "GET", "OPTIONS", "DELETE"])
-@API.doc(params={"user_id": "The user identifier"})
+@API.route("/<username>", methods=["PATCH", "GET", "OPTIONS", "DELETE"])
+@API.doc(params={"username": "The user identifier"})
 class User(Resource):
     """Resource for managing a single user."""
 
@@ -78,11 +78,32 @@ class User(Resource):
     @ApiHelper.swagger_decorators(API, endpoint_description="Fetch a user by id")
     @API.response(code=200, model=user_list_model, description="Success")
     @API.response(404, "Not Found")
-    def get(user_id):
-        """Fetch a user by id."""
-        user = UserService.get_user_by_id(user_id)
+    def get(username):
+        """Fetch a user by username."""
+        group_brief_representation = request.args.get("group_brief_representation", "false").lower() == "true"
+        user = UserService.get_user_by_username(username, group_brief_representation)
         if not user:
-            raise ResourceNotFoundError(f"User with {user_id} not found")
+            raise ResourceNotFoundError(f"User with {username} not found")
+        return UserSchema().dump(user), HTTPStatus.OK
+
+
+@cors_preflight("GET, OPTIONS, PATCH, DELETE")
+@API.route("/guid/<user_auth_guid>", methods=["PATCH", "GET", "OPTIONS", "DELETE"])
+@API.doc(params={"username": "The user identifier"})
+class UserById(Resource):
+    """Resource for managing a single user."""
+
+    @staticmethod
+    @auth.require
+    @ApiHelper.swagger_decorators(API, endpoint_description="Fetch a user by id")
+    @API.response(code=200, model=user_list_model, description="Success")
+    @API.response(404, "Not Found")
+    def get(user_auth_guid):
+        """Fetch a user by username."""
+        group_brief_representation = request.args.get("group_brief_representation", "false").lower() == "true"
+        user = UserService.get_user_by_id(user_auth_guid, group_brief_representation)
+        if not user:
+            raise ResourceNotFoundError(f"User {user_auth_guid} not found")
         return UserSchema().dump(user), HTTPStatus.OK
 
     @staticmethod
@@ -125,7 +146,7 @@ class UserGroups(Resource):
     @API.response(404, "Not Found")
     def get(user_id):
         """Fetch groups for a user by id."""
-        groups = UserService.get_groups_by_user_id(user_id)
+        groups = UserService.get_groups_by_username(user_id)
         if not groups:
             raise ResourceNotFoundError(f"No groups found for user with {user_id}")
         return UserGroupResponseSchema(many=True).dump(groups), HTTPStatus.OK

--- a/auth-api/src/auth_api/schemas/user.py
+++ b/auth-api/src/auth_api/schemas/user.py
@@ -23,6 +23,7 @@ class UserSchema(Schema):
     email = fields.Str(data_key="email_address")
     username = fields.Str(data_key="username")
     groups = fields.List(fields.Nested(UserGroupResponseSchema))
+    enabled = fields.Bool(data_key="enabled")
 
     @pre_dump
     def convert_keys(self, data, **kwargs):

--- a/auth-api/src/auth_api/services/keycloak.py
+++ b/auth-api/src/auth_api/services/keycloak.py
@@ -44,7 +44,7 @@ class KeycloakService:
         return response.json()
 
     @staticmethod
-    def get_user_by_id(username):
+    def get_user_by_username(username):
         """Get users."""
         response = KeycloakService._request_keycloak(f"users?username={username}")
         users = response.json()
@@ -54,6 +54,18 @@ class KeycloakService:
 
         # Assuming usernames are unique, return the first user found
         return users[0]
+
+    @staticmethod
+    def get_user_by_id(user_id):
+        """Get users."""
+        response = KeycloakService._request_keycloak(f"users/{user_id}")
+        user = response.json()
+
+        if not user:
+            raise ValueError(f"User not found.")
+
+        # Assuming usernames are unique, return the first user found
+        return user
 
     @staticmethod
     def get_users(search_text: str = None):
@@ -101,7 +113,7 @@ class KeycloakService:
     @staticmethod
     def update_user_group(user_id, group_id):
         """Update the group of user."""
-        kc_user_id = KeycloakService.get_user_by_id(user_id)["id"]
+        kc_user_id = KeycloakService.get_user_by_username(user_id)["id"]
         return KeycloakService._request_keycloak(
             f"users/{kc_user_id}/groups/{group_id}", HttpMethod.PUT
         )
@@ -109,7 +121,7 @@ class KeycloakService:
     @staticmethod
     def delete_user_group(user_id, group_id):
         """Delete user-group mapping."""
-        kc_user_id = KeycloakService.get_user_by_id(user_id)["id"]
+        kc_user_id = KeycloakService.get_user_by_username(user_id)["id"]
         return KeycloakService._request_keycloak(
             f"users/{kc_user_id}/groups/{group_id}", HttpMethod.DELETE
         )
@@ -139,10 +151,11 @@ class KeycloakService:
         return response
 
     @staticmethod
-    def get_user_groups(user_id):
+    def get_user_groups_by_username(username, user_id=None, brief_representation=False):
         """Get groups directly associated with a specific user by their ID."""
-        kc_user_id = KeycloakService.get_user_by_id(user_id)["id"]
-        response = KeycloakService._request_keycloak(f"users/{kc_user_id}/groups")
+        if user_id:
+            user_id = KeycloakService.get_user_by_username(username)["id"]
+        response = KeycloakService._request_keycloak(f"users/{user_id}/groups?briefRepresentation={brief_representation}")
         return response.json()
 
     @staticmethod

--- a/auth-api/src/auth_api/services/user_service.py
+++ b/auth-api/src/auth_api/services/user_service.py
@@ -12,13 +12,26 @@ class UserService:
     """User management service."""
 
     @classmethod
-    def get_user_by_id(cls, user_id):
-        """Get user by id."""
+    def get_user_by_id(cls, user_id, group_brief_representation=False):
+        """Get user by username."""
         app_name = g.app_name
         user = KeycloakService.get_user_by_id(user_id)
+        username = user.get("username")
+        enriched_user = cls.enrich_user_with_groups(app_name, group_brief_representation, user, user_id, username)
+        return enriched_user
 
-        user_groups = KeycloakService.get_user_groups(user_id)
+    @classmethod
+    def get_user_by_username(cls, username, group_brief_representation=False):
+        """Get user by username."""
+        app_name = g.app_name
+        user = KeycloakService.get_user_by_username(username)
+        user_id = user.get("id")
+        enriched_user = cls.enrich_user_with_groups(app_name, group_brief_representation, user, user_id, username)
+        return enriched_user
 
+    @classmethod
+    def enrich_user_with_groups(cls, app_name, group_brief_representation, user, user_id, username):
+        user_groups = KeycloakService.get_user_groups_by_username(username, user_id, group_brief_representation)
         app_groups = (
             [
                 group
@@ -28,7 +41,6 @@ class UserService:
             if app_name
             else user_groups
         )
-
         # Add groups to user data
         user["groups"] = app_groups
         return user
@@ -150,7 +162,7 @@ class UserService:
                     "The requested action will delete all the subgroup mappings of the"
                     "given parent. Please pass 'del_sub_group_mappings' as 'true' if you want to proceed."
                 )
-            mapped_groups = cls.get_groups_by_user_id(user_id)
+            mapped_groups = cls.get_groups_by_username(user_id)
             mapped_sub_groups = [
                 mapped
                 for mapped in mapped_groups
@@ -176,9 +188,9 @@ class UserService:
         return all_groups
 
     @classmethod
-    def get_groups_by_user_id(cls, user_id):
+    def get_groups_by_username(cls, username):
         """Get groups for a specific user by their ID."""
-        groups = KeycloakService.get_user_groups(user_id)
+        groups = KeycloakService.get_user_groups_by_username(username)
         return groups
 
     @classmethod


### PR DESCRIPTION
Refactors the user lookup functionality to support retrieval by both username and user ID.

- Adds a new endpoint for fetching users by ID.
- Modifies existing endpoint to fetch users by username.
- Updates the user service to handle both lookup methods.
- Adds 'enabled' field to the User schema.

Relates to CENTRE-29